### PR TITLE
make installation_id optional

### DIFF
--- a/api/oauth/post.ts
+++ b/api/oauth/post.ts
@@ -8,7 +8,7 @@ import { Octokit } from "@octokit/rest";
 import jsonwebtoken from "jsonwebtoken";
 
 const zCustomParams = z.object({
-  installation_id: z.string(),
+  installation_id: z.string().optional(),
 });
 
 const logic = async (
@@ -62,7 +62,7 @@ const logic = async (
         ),
       }).apps
         .getInstallation({
-          installation_id: Number(customParams.data.installation_id),
+          installation_id: Number(customParams.data?.installation_id),
         })
         .then((r) => r.data.account?.login ?? "")
     : "";


### PR DESCRIPTION
The app workflow request user authorization after installation.

![image](https://github.com/samepage-network/github-samepage/assets/3792666/d44089e3-0532-411f-bac4-e989a58aa2e9)

The auth_code is stored in local storage.  If it is removed, the users needs to give auth again, but the app is already installed.

In this flow, the installation_id isn't sent, but is required here and on `samepage.network/oauth`

This PR makes that optional.
